### PR TITLE
Library renamed on tvOS to support SPM.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "BLAdFramework",
-            targets: ["BLAdFramework"]),
+            name: "BLAdFramework_TVOS",
+            targets: ["BLAdFramework_TVOS"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -22,7 +22,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .binaryTarget(
-                    name: "BLAdFramework",
+                    name: "BLAdFramework_TVOS",
                     path: "BLAdFramework.xcframework"
         )
     ]


### PR DESCRIPTION
NBC's CVSDK team has experienced the same issue presented in here: https://github.com/BrightLine-iTV/blsdk-ios-spm/issues/2.
As we have one project with multiple targets (multiplatform, too) it is currently not possible to add both iOS and tvOS xcframeworks in the same project via SPM. For example:
![Screenshot 2024-10-02 at 4 45 43 PM](https://github.com/user-attachments/assets/050525bb-a784-436c-8921-efceaadfc086)

When attempting to do this with the current implementation, we face the following error:
multiple products named `BLAdFramework`
![Screenshot 2024-10-02 at 4 28 07 PM](https://github.com/user-attachments/assets/dc47f853-430a-448b-b367-8cc3762586c3)

This is caused because the library and target for both iOS and tvOS frameworks are named the same. When renamed to something different than the name used in iOS, the issue is fixed and Xcode can resolve the package cloning.